### PR TITLE
switched to JSONAPI for demostration

### DIFF
--- a/frontend/app/adapters/application.js
+++ b/frontend/app/adapters/application.js
@@ -1,4 +1,7 @@
 import DS from 'ember-data';
 
-export default DS.RESTAdapter.extend({
+export default DS.JSONAPIAdapter.extend({
+  coalesceFindRequests: true,
+  shouldReloadRecord: () => false,
+  shouldBackgroundReloadRecord: () => false,
 });

--- a/frontend/app/routes/series.js
+++ b/frontend/app/routes/series.js
@@ -4,11 +4,16 @@ import { inject } from '@ember/service';
 export default Route.extend({
   store: inject(),
 
-  async afterModel(series, {to}) {
-    await this.store.query('exercise',{});
-    if (to.name === 'series.index' && series.exercises.firstObject) {
-      this.transitionTo('series.exercise', series.exercises.firstObject)
-    }
+  model({ series_id }) {
+    return this.store.findRecord('series', series_id, { include: 'exercises' });
   },
 
+  async afterModel(series, { to }) {
+    // in case if series was pre-loaded
+    // asking for exercises again
+    await series.hasMany('exercises').load();
+    if (to.name === 'series.index' && series.exercises.firstObject) {
+      this.transitionTo('series.exercise', series.exercises.firstObject);
+    }
+  },
 });

--- a/frontend/app/routes/series/exercise.js
+++ b/frontend/app/routes/series/exercise.js
@@ -4,14 +4,16 @@ import { inject } from '@ember/service';
 export default Route.extend({
   store: inject(),
 
-  model({exercise_id:exerciseId}) {
-    return this.store.queryRecord('exercise',exerciseId);
+  model({ exercise_id }) {
+    return this.store.findRecord('exercise', exercise_id, { include: 'tasks' });
   },
 
-  async afterModel(exercise,{to}) {
-    await this.store.query('task',{exerciseId:exercise.id});
+  async afterModel(exercise, { to }) {
+    // in case if exercise was pre-loaded
+    // asking for tasks again
+    await exercise.hasMany('tasks').load();
     if (to.name.endsWith('exercise.index') && exercise.tasks.firstObject) {
-      this.transitionTo('series.exercise.task', exercise.tasks.firstObject)
+      this.transitionTo('series.exercise.task', exercise.tasks.firstObject);
     }
-  }
+  },
 });

--- a/frontend/mirage/serializers/application.js
+++ b/frontend/mirage/serializers/application.js
@@ -1,4 +1,5 @@
-import { RestSerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'ember-cli-mirage';
 
-export default RestSerializer.extend({
+export default JSONAPISerializer.extend({
+  alwaysIncludeLinkageData: true,
 });


### PR DESCRIPTION
Switched application and mirage config to use JSONAPI. Now we can easily inspect expected API using devtools:
![image](https://user-images.githubusercontent.com/697625/66915782-873d3300-f022-11e9-96fb-7c74a5546e6f.png)


To see this 👆:
 - switch to JSONAPI-demo branch
 - start FE dev server ([instructions](https://github.com/ElenaSpb/brn#fe-dev-pre-requisites))
 - open http://localhost:4200
 - checkout browser console (`Ctrl + Shift + J`)